### PR TITLE
feature/reverse-download-filename

### DIFF
--- a/src/DoxieConsumer.php
+++ b/src/DoxieConsumer.php
@@ -78,8 +78,8 @@ class DoxieConsumer {
      * @return string
      */
     public function generate_download_filename($doxie_scan){
-        $download_filename  = pathinfo($doxie_scan->name, PATHINFO_FILENAME).'.';
-        $download_filename .= date("YmdHis", strtotime($doxie_scan->modified));
+        $download_filename  = date("YmdHis", strtotime($doxie_scan->modified)).'.';
+        $download_filename .= pathinfo($doxie_scan->name, PATHINFO_FILENAME);
         $download_filename .= '.'.pathinfo($doxie_scan->name, PATHINFO_EXTENSION);
         return $download_filename;
     }

--- a/tests/DoxieConsumerTest.php
+++ b/tests/DoxieConsumerTest.php
@@ -176,8 +176,8 @@ class DoxieConsumerTest extends PHPUnit_Framework_TestCase {
     public function generate_download_filename(){
         $doxie_scan = $this->generate_generic_doxie_scan();
 
-        $download_filename  = pathinfo($doxie_scan->name, PATHINFO_FILENAME).'.';
-        $download_filename .= date("YmdHis", strtotime($doxie_scan->modified));
+        $download_filename  = date("YmdHis", strtotime($doxie_scan->modified)).'.';
+        $download_filename .= pathinfo($doxie_scan->name, PATHINFO_FILENAME);
         $download_filename .= '.'.pathinfo($doxie_scan->name, PATHINFO_EXTENSION);
 
         $doxie = new DoxieConsumer();


### PR DESCRIPTION
Putting the date for downloaded files first in the generated filename. Files are easier to find that way.