### PR TITLE
Release/1.2.1

### DIFF
--- a/src/DoxieConsumer.php
+++ b/src/DoxieConsumer.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ .'/../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/DoxieScan.php';
 
 /**
@@ -206,6 +206,12 @@ class DoxieConsumer {
         }
     }
 
+    /**
+     * Downloads file in URL to specified location
+     * @param string $request_url
+     * @param string $download_location
+     * @return bool
+     */
     private function get_file($request_url, $download_location){
         $this->are_dependencies_set();
         $this->logger->debug("Calling: GET ".$request_url."\nDownloading scan to: ".$download_location);

--- a/src/DoxieScan.php
+++ b/src/DoxieScan.php
@@ -15,7 +15,11 @@ class DoxieScan {
         }
         $this->name = $doxie_item['name'];
         $this->size = $doxie_item['size'];
-        $this->modified = $doxie_item['modified'];
+        if(empty($doxie_item['modified'])){
+            $this->modified = date('Y-m-d H:i:s');
+        } else {
+            $this->modified = $doxie_item['modified'];
+        }
     }
 
     public function __get($key){

--- a/src/consumer.php
+++ b/src/consumer.php
@@ -35,8 +35,8 @@ if($verbose_flag){
 
 // Setup a request client
 $request_client = new Guzzle\Http\Client();
-$request_client->setDefaultOption('timeout', 10);
-$request_client->setDefaultOption('connect_timeout', 5);
+$request_client->setDefaultOption('timeout', 30);
+$request_client->setDefaultOption('connect_timeout', 3);
 
 // Initialise doxie consumer
 $doxie_consumer = new DoxieConsumer();

--- a/tests/DoxieScanTest.php
+++ b/tests/DoxieScanTest.php
@@ -1,0 +1,70 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../src/DoxieConsumer.php';
+
+class DoxieScanTest extends PHPUnit_Framework_TestCase {
+
+    private function generate_test_doxie_scan_array(){
+        return array(
+            'name'=>'test.jpg',
+            'size'=>0,
+            'modified'=>date('Y-m-d H:i:s')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function get_doxie_scan_from_array(){
+        $test_doxie_scan_array = $this->generate_test_doxie_scan_array();
+
+        $doxie_scan_object = new DoxieScan($test_doxie_scan_array);
+        $this->assertEquals($test_doxie_scan_array['name'], $doxie_scan_object->name);
+        $this->assertEquals($test_doxie_scan_array['size'], $doxie_scan_object->size);
+        $this->assertEquals($test_doxie_scan_array['modified'], $doxie_scan_object->modified);
+    }
+
+    /**
+     * @test
+     */
+    public function get_doxie_scan_from_json(){
+        $test_doxie_scan_array = $this->generate_test_doxie_scan_array();
+        $test_doxie_scan_json = json_encode($test_doxie_scan_array);
+
+        $doxie_scan_object = new DoxieScan($test_doxie_scan_json);
+        $this->assertEquals($test_doxie_scan_array['name'], $doxie_scan_object->name);
+        $this->assertEquals($test_doxie_scan_array['size'], $doxie_scan_object->size);
+        $this->assertEquals($test_doxie_scan_array['modified'], $doxie_scan_object->modified);
+    }
+
+    /**
+     * @test
+     */
+    public function get_doxie_scan_as_string(){
+        $test_doxie_scan_array = $this->generate_test_doxie_scan_array();
+        $test_doxie_scan_json = json_encode($test_doxie_scan_array);
+
+        $doxie_scan_object = new DoxieScan($test_doxie_scan_array);
+        $this->assertEquals($test_doxie_scan_json, (string) $doxie_scan_object);
+    }
+
+
+    /**
+     * @test
+     */
+    public function get_doxie_scan_without_modified_component(){
+        $test_doxie_scan_array = $this->generate_test_doxie_scan_array();
+        $test_doxie_scan_array['modified'] = '';
+        $this->assertEmpty($test_doxie_scan_array['modified']);
+
+        $now = date('Y-m-d H:i:s');
+        $doxie_scan_object = new DoxieScan($test_doxie_scan_array);
+        $this->assertNotEmpty($doxie_scan_object->modified);
+        $this->assertNotEquals($test_doxie_scan_array['modified'], $doxie_scan_object->modified);
+        $this->assertEquals($now, $doxie_scan_object->modified);
+        $this->assertEquals($test_doxie_scan_array['name'], $doxie_scan_object->name);
+        $this->assertEquals($test_doxie_scan_array['size'], $doxie_scan_object->size);
+    }
+
+}


### PR DESCRIPTION
- Increase timeout from 10 to 30 seconds to allow for downloading larger files.
- Decreased connection timeout from 5 to 3 seconds.
- Added a check to make sure a Doxie scan has a modified timestamp. If not, one is assigned.
- Added PHPUnit tests for the DoxieScan object