### PR TITLE
Release/1.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   }],
   "require": {
     "guzzle/guzzle": "^3.9",
-    "vlucas/phpdotenv": "1.0.6",
+    "vlucas/phpdotenv": "^1.1",
     "phine/phar": "~1.0",
     "monolog/monolog": "^1.22",
     "nategood/commando": "^0.2.9",

--- a/src/DoxieConsumer.php
+++ b/src/DoxieConsumer.php
@@ -4,6 +4,7 @@ namespace jdenoc\DoxieConsumer;
 
 use Guzzle;
 use Monolog;
+use Dotenv;
 use jdenoc\NetworkScanner\NetworkScanner;
 
 /**
@@ -12,6 +13,8 @@ use jdenoc\NetworkScanner\NetworkScanner;
  */
 class DoxieConsumer {
 
+    const ENV_KEY_PHYSICAL_ADDRESS = 'DOXIE_PHYSICAL_ADDRESS';
+    const ENV_KEY_DOWNLOAD_LOCATION = 'DOWNLOAD_LOCATION';
     const URI_STATUS = '/hello.json';
     const URI_LIST = '/scans.json';
     const URI_FILE_PREFIX = '/scans';
@@ -38,6 +41,11 @@ class DoxieConsumer {
      * @var string
      */
     private $scanner_ip_address;
+
+    public function __construct(){
+        Dotenv::required(self::ENV_KEY_PHYSICAL_ADDRESS);
+        Dotenv::required(self::ENV_KEY_DOWNLOAD_LOCATION);
+    }
 
     /**
      * @param Guzzle\Http\Client $request_client
@@ -104,7 +112,7 @@ class DoxieConsumer {
      * @return string
      */
     public function get_doxie_physical_address(){
-        $physical_address = getenv("DOXIE_PHYSICAL_ADDRESS");
+        $physical_address = getenv(self::ENV_KEY_PHYSICAL_ADDRESS);
         return $physical_address;
     }
 
@@ -133,7 +141,7 @@ class DoxieConsumer {
      * @return string
      */
     public function get_download_location(){
-        $location = getenv("DOWNLOAD_LOCATION");
+        $location = getenv(self::ENV_KEY_DOWNLOAD_LOCATION);
         return rtrim($location, '/');
     }
 

--- a/tests/DoxieConsumerTest.php
+++ b/tests/DoxieConsumerTest.php
@@ -56,7 +56,7 @@ class DoxieConsumerTest extends PhpUnitTestCase {
     public function setup_network_scanner(){
         $this->_network_scanner = new NetworkScanner\Tests\NetworkScanner();
         $this->_network_scanner->set_detectable_os(NetworkScanner\NetworkScanner::OS_LINUX);
-        $this->_network_scanner->add_mac_address_to_response('127.0.0.1', getenv("DOXIE_PHYSICAL_ADDRESS"));
+        $this->_network_scanner->add_mac_address_to_response('127.0.0.1', getenv(DoxieConsumer::ENV_KEY_PHYSICAL_ADDRESS));
     }
 
     /**


### PR DESCRIPTION
- Forcing the environment variables to be set, otherwise the consumer will not work.
- Replaced text for environment variable names with constants.
- Bumped `vlucas/phpdotenv` version.