### PR TITLE
Feat/docker-entrypoint

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -58,10 +58,6 @@ FROM base as final
 
 ENV SCANNER_HOST=doxie.scanner
 
-ENV LOGS_DIR=/var/log/doxie-consumer
-RUN mkdir --parents $LOGS_DIR \
-    && chown --recursive $USER $LOGS_DIR
-
 WORKDIR /opt/doxie
 COPY --from=compile-phar /opt/doxie-consumer/consumer.phar /opt/doxie/consumer.phar
 RUN chown --recursive $USER /opt/doxie; \
@@ -79,4 +75,4 @@ LABEL org.opencontainers.image.version="$APP_VERSION"
 ARG BUILD_DATETIME
 LABEL org.opencontainers.image.created="$BUILD_DATETIME"
 
-CMD ["php", "/opt/doxie/consumer.phar", "-vvv", "--", "$SCANNER_HOST", "$DOWNLOAD_DIR", ">>", "$LOGS_DIR/$(date '+%Y%m%d').log"]
+CMD ["php", "/opt/doxie/consumer.phar", "-vvv", "--", "$SCANNER_HOST", "$DOWNLOAD_DIR"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -75,4 +75,5 @@ LABEL org.opencontainers.image.version="$APP_VERSION"
 ARG BUILD_DATETIME
 LABEL org.opencontainers.image.created="$BUILD_DATETIME"
 
-CMD ["php", "/opt/doxie/consumer.phar", "-vvv", "--", "$SCANNER_HOST", "$DOWNLOAD_DIR"]
+ENTRYPOINT ["/opt/doxie/consumer.phar"]
+CMD ["-vvv", "--", "$SCANNER_HOST", "$DOWNLOAD_DIR"]

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ docker image pull ghcr.io/jdenoc/doxie-consumer
 ```
 
 ### Run container
-```shell
+```sh
 docker run --rm \
   --env SCANNER_HOST=doxie.scanner \
   --volume /host/machine/path/to/scans:/opt/doxie/scans \
-  --volume /host/machine/path/to/logs:/var/log/doxie-consumer \
-  docker-consumer
+  doxie-consumer
 ```
 
 ### Build image locally
@@ -69,8 +68,7 @@ vendor/bin/box validate && \
 ```sh
 export SCANNER_HOST=doxie.scanner
 export DOWNLOAD_DIR=/path/to/downloads
-export LOGS_DIR=/path/to/logs
-php consumer.phar -vvv -- $SCANNER_HOST $DOWNLOAD_DIR >> $LOGS_DIR/$(date '+%Y%m%d').log
+php consumer.phar -vvv -- $SCANNER_HOST $DOWNLOAD_DIR
 ```
 
 ---


### PR DESCRIPTION
- Removed reference to a logs directory from the Docker container.
- Switch to using `ENTRYPOINT` & `CMD` instead of just `CMD` to make running the container to be more like a regular executable.